### PR TITLE
Back-end now returns task id when task is created

### DIFF
--- a/auth/auth-router.js
+++ b/auth/auth-router.js
@@ -73,7 +73,7 @@ router.post('/login', validationLogin, (req, res) => {
         const token = generateToken(user)
         console.log(user)
         res.status(200).json({
-          message: `Welcome ${user.username}!`,
+          message: `Welcome ${user.displayName}!`,
           user: user,
           token
         });

--- a/users/users-router.js
+++ b/users/users-router.js
@@ -24,7 +24,7 @@ router.post('/:id/tasks', restricted, (req, res) => {
 
   Tasks.add(task)
     .then(newTask => {
-      res.status(201).json({message: 'Task created successfully', id: newTask});
+      res.status(201).json({message: 'Task created successfully', id: newTask[0]});
     })
     .catch(err => {
       res.status(500).json({ message: 'Failed to create new task' });

--- a/users/users-router.js
+++ b/users/users-router.js
@@ -23,8 +23,8 @@ router.post('/:id/tasks', restricted, (req, res) => {
   console.log(id)
 
   Tasks.add(task)
-    .then(task => {
-      res.status(201).json('task created successfully');
+    .then(newTask => {
+      res.status(201).json({message: 'Task created successfully', id: newTask});
     })
     .catch(err => {
       res.status(500).json({ message: 'Failed to create new task' });


### PR DESCRIPTION
# Description
This addition changes the back-end response to when a task is created and saved in the database. Previously, it would only respond with a message. This update sends a response with a message and the task id. The front-end people need the task id in order to connect it with a category.

- [x] New feature (non-breaking change which adds functionality)

## Change Status

- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
Tested on local machine with Postman

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts







