### PR TITLE
Fix: Add tasks not returns task id.

### DIFF
--- a/tasks/tasks-model.js
+++ b/tasks/tasks-model.js
@@ -27,7 +27,10 @@ function findTasks(id) {
 
 function add(task) {
     return db('tasks')
-        .insert(task)
+        .insert(task, 'id')
+        .then(([id]) => {
+            return findById(id);
+        })
 }
 
 function update(task, id) {

--- a/users/users-router.js
+++ b/users/users-router.js
@@ -25,10 +25,9 @@ router.post('/:id/tasks', restricted, (req, res) => {
 
   Tasks.add(task)
     .then(newTask => {
-      console.log(newTask)
       res.status(201).json({
-        id: newTask[0],
-        message: 'Task created successfully'        
+        message: 'Task created successfully',
+        id: newTask.id        
       });
     })
     .catch(err => {


### PR DESCRIPTION
# Description
Adding a task was not set up to return the task id in the postgres format. This PR fixes that.

Fixes # 
Have model return task that was just created.
Have route set id to newtask.id.

## Type of change

Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)

## Change Status
- [ ] Complete, tested, ready to review and merge

# How Has This Been Tested?
Tested with Postman

# Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts







