### PR TITLE
Fix issue of not being able to delete a task

### DIFF
--- a/database/migrations/20200625001209_create-table.js
+++ b/database/migrations/20200625001209_create-table.js
@@ -1,0 +1,18 @@
+exports.up = function(knex) {
+  return (
+      knex.schema
+        .alterTable('task-categories', table => {
+            table.integer('task_id')
+                    .unsigned()
+                    .notNullable()
+                    .references('id')
+                    .inTable('tasks')
+                    .onUpdate('CASCADE')
+                    .onDelete('CASCADE');
+        })
+  )
+};
+
+exports.down = function(knex) {
+  
+};

--- a/users/users-router.js
+++ b/users/users-router.js
@@ -87,17 +87,20 @@ router.put('/tasks/:id', restricted, (req, res) => {
 router.delete('/tasks/:id', restricted, (req, res) => {
   const { id } = req.params;
 
-  Tasks.remove(id)
-    .then(deleted => {
-      if (deleted) {
-        res.json({ removed: deleted });
+  Tasks.findById(id)
+    .then(task => {
+      if (task) {
+        Tasks.remove(id)
+          .then(deleted => { 
+            res.json({ removed: deleted });
+        })
       } else {
-        res.status(404).json({ message: 'Could not find task with given id' });
+        res.status(404).json({message: 'Could not find task with given id'})
       }
     })
     .catch(err => {
-      res.status(500).json({ message: 'Failed to delete task' });
-    });
+      res.statusMessage(500).json({message: 'Failed to delete task'})
+    })
 });
 
 //Validate Middleware


### PR DESCRIPTION
# Description
The app was unable to delete tasks. This is because the router delete for user tasks was not adjusted for a postgres database. There was also an issue with an intermediate table not cascading the delete.

Fixes # (issue)
The delete task route was adjusted to find the task by id and then delete. This resulted in an database error because the task id was a foreign key in and intermediate table. The intermediate table was adjusted to cascade the delete on the task.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Change Status
- [x] Complete, tested, ready to review and merge

# How Has This Been Tested?
I have a copy of the front-end and back-end in my own repo. I was able to update my own database and test it with the front-end. I was able to create and delete tasks multiple times.

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [x] There are no merge conflicts







